### PR TITLE
Adding name attribute to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "vc2010"
 maintainer       "Webtrends Inc."
 maintainer_email "david.dvorak@webtrends.com"
 license          "All rights reserved"


### PR DESCRIPTION
I was getting errors because there was no `name` parameter in the `metadata.rb` file.

Example:

```
[2015-12-11T12:56:13-07:00] ERROR: #<Chef::Exceptions::MetadataNotValid: Cookbook loaded at path(s) [C:/vagrant-chef/0e5f936a73f2aba58962dbac3237c6e8/cookbooks/vc2010] has invalid metadata: The `name' attribute is required in cookbook metadata>
```
